### PR TITLE
fix cloud rendering in VR

### DIFF
--- a/Constraints.cs
+++ b/Constraints.cs
@@ -5,6 +5,8 @@ using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 
+// OnPreCull used to override VR HMD tracking
+// https://forum.unity.com/threads/how-to-disable-hmd-movement-for-second-camera.482468/#post-4282909
 namespace ProceduralSkyMod
 {
 	public class SkyCamConstraint : MonoBehaviour
@@ -13,7 +15,7 @@ namespace ProceduralSkyMod
 		public Camera sky;
 		public Camera clear;
 
-		void Update ()
+		void OnPreCull()
 		{
 			clear.transform.rotation = sky.transform.rotation = main.transform.rotation;
 			clear.fieldOfView = sky.fieldOfView = main.fieldOfView;
@@ -25,10 +27,10 @@ namespace ProceduralSkyMod
 		public Transform source = null;
 		public Transform target = null;
 
-		void Update ()
+		void OnPreCull ()
 		{
 			if (source == null) return;
-			if (target == null) this.transform.position = source.transform.position;
+			if (target == null) transform.position = source.transform.position;
 			else target.transform.position = source.transform.position;
 		}
 	}

--- a/ProceduralSkyInitializer.cs
+++ b/ProceduralSkyInitializer.cs
@@ -88,7 +88,6 @@ namespace ProceduralSkyMod
 			Camera skyCam = new GameObject() { name = "SkyCam" }.AddComponent<Camera>();
 			skyCam.transform.SetParent(psMaster.transform);
 			skyCam.transform.ResetLocal();
-			SkyCamConstraint constraint = skyCam.gameObject.AddComponent<SkyCamConstraint>();
 			skyCam.clearFlags = CameraClearFlags.Depth;
 			skyCam.cullingMask = 0;
 			skyCam.cullingMask |= 1 << 31;
@@ -105,6 +104,14 @@ namespace ProceduralSkyMod
 			clearCam.cullingMask = 0;
 			clearCam.depth = -3;
 			clearCam.fieldOfView = mainCam.fieldOfView;
+
+			SkyCamConstraint constraint = skyCam.gameObject.AddComponent<SkyCamConstraint>();
+			constraint.main = mainCam;
+			constraint.sky = skyCam;
+			constraint.clear = clearCam;
+
+			PositionConstraint overrideHMD = skyCam.gameObject.AddComponent<PositionConstraint>();
+			overrideHMD.source = psMaster.transform;
 
 			// cloud render texture cam
 			Camera cloudRendTexCam = new GameObject() { name = "CloudRendTexCam" }.AddComponent<Camera>();
@@ -129,10 +136,6 @@ namespace ProceduralSkyMod
 			cloudRendTexCam.forceIntoRenderTexture = true;
 			WeatherSource.CloudRenderTexCam = cloudRendTexCam;
 			cloudRendTexCam.enabled = false; // disable the camera, renders will be triggered by script
-
-			constraint.main = mainCam;
-			constraint.sky = skyCam;
-			constraint.clear = clearCam;
 
 #if DEBUG
 			Debug.Log(">>> >>> >>> Setting Up Audio Sources...");


### PR DESCRIPTION
Forces `skyCam` to be locked at `psMaster.transform.position` even with the HMD tracking script is in effect.